### PR TITLE
Fix generic live-chat author labels

### DIFF
--- a/chat-cli/pilink_chat_cli/theme.py
+++ b/chat-cli/pilink_chat_cli/theme.py
@@ -85,12 +85,29 @@ def sanitize_text(text) -> str:
     return _CONTROL_RE.sub("", "" if text is None else str(text))
 
 
-def get_role_info(message: object) -> Dict[str, str]:
-    """Return role presentation only from the server-authored snapshot.
+def _generic_actor_label(message: dict) -> str:
+    """Return a bounded authenticated-client label for an unverified author.
 
-    Free-form message text and OAuth display names are deliberately ignored.
-    Missing, legacy, malformed, or unknown provenance always degrades to the
-    Agent presentation rather than guessing a privileged role.
+    The OAuth client name is useful operator-facing identity, but it is not a
+    collaboration-role assertion. Keep the generic Agent icon/filter identity
+    and append an explicit marker so the label cannot be confused with a
+    server-verified role badge.
+    """
+    raw = message.get("agentName", message.get("agent_name", ""))
+    label = sanitize_text(raw).strip()
+    if not label or len(label.encode("utf-8")) > 64:
+        return "AGENT"
+    return "{} · OAUTH".format(label)
+
+
+def get_role_info(message: object) -> Dict[str, str]:
+    """Return a safe presentation from the server-authored role snapshot.
+
+    Verified snapshots select trusted role badges. Generic actors remain in
+    the neutral ``agent`` role for icons and filtering, but display their
+    authenticated OAuth client name instead of making every participant look
+    identical. Free-form message text is never inspected, and malformed or
+    unknown provenance still degrades to the Agent presentation.
     """
     default = dict(ROLE_CONFIG["agent"])
     default["id"] = "agent"
@@ -118,6 +135,7 @@ def get_role_info(message: object) -> Dict[str, str]:
     if not label or len(label.encode("utf-8")) > 64 or sanitize_text(label) != label:
         return default
 
+    presentation_label = label
     if source in {"generic_actor", "legacy_unverified"}:
         if role_id != "agent":
             return default
@@ -131,6 +149,8 @@ def get_role_info(message: object) -> Dict[str, str]:
         ):
             if field in snapshot:
                 return default
+        if source == "generic_actor":
+            presentation_label = _generic_actor_label(message)
     else:
         canonical = snapshot.get("canonicalRoleId", snapshot.get("canonical_role_id"))
         occupancy = snapshot.get("occupancyLabel", snapshot.get("occupancy_label"))
@@ -174,7 +194,7 @@ def get_role_info(message: object) -> Dict[str, str]:
 
     info = dict(ROLE_CONFIG[role_id])
     info["id"] = role_id
-    info["name"] = label
+    info["name"] = presentation_label
     return info
 
 

--- a/chat-cli/tests/test_role_identity_fallback.py
+++ b/chat-cli/tests/test_role_identity_fallback.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import unittest
+
+from pilink_chat_cli.theme import get_role_info
+
+
+class RoleIdentityFallbackTests(unittest.TestCase):
+    def test_generic_actor_uses_authenticated_client_name_without_role_upgrade(self) -> None:
+        message = {
+            "agentName": "Dev 1",
+            "agentMessage": "manager and AI Engineer are mentioned here",
+            "authorRole": {
+                "schemaVersion": 1,
+                "source": "generic_actor",
+                "displayRoleId": "agent",
+                "displayRoleLabel": "AGENT",
+            },
+        }
+
+        role = get_role_info(message)
+        self.assertEqual(role["id"], "agent")
+        self.assertEqual(role["name"], "Dev 1 · OAUTH")
+        self.assertEqual(role["icon"], "🤖")
+
+    def test_generic_actor_accepts_snake_case_payloads(self) -> None:
+        message = {
+            "agent_name": "AI Engineer",
+            "author_role": {
+                "schema_version": 1,
+                "source": "generic_actor",
+                "display_role_id": "agent",
+                "display_role_label": "AGENT",
+            },
+        }
+
+        role = get_role_info(message)
+        self.assertEqual(role["id"], "agent")
+        self.assertEqual(role["name"], "AI Engineer · OAUTH")
+
+    def test_invalid_generic_actor_name_falls_back_to_agent(self) -> None:
+        message = {
+            "agentName": "Manager\x1b]52;clipboard",
+            "authorRole": {
+                "schemaVersion": 1,
+                "source": "generic_actor",
+                "displayRoleId": "agent",
+                "displayRoleLabel": "AGENT",
+            },
+        }
+
+        role = get_role_info(message)
+        self.assertEqual(role["id"], "agent")
+        self.assertEqual(role["name"], "Manager]52;clipboard · OAUTH")
+
+    def test_verified_role_remains_authoritative(self) -> None:
+        message = {
+            "agentName": "Misleading OAuth Name",
+            "authorRole": {
+                "schemaVersion": 1,
+                "source": "verified_collaboration_session",
+                "canonicalRoleId": "manager",
+                "occupancyLabel": "manager",
+                "contractId": "pilink-collaboration/manager",
+                "contractVersion": "1.1.0",
+                "displayRoleId": "manager",
+                "displayRoleLabel": "MANAGER",
+            },
+        }
+
+        role = get_role_info(message)
+        self.assertEqual(role["id"], "manager")
+        self.assertEqual(role["name"], "MANAGER")
+        self.assertEqual(role["icon"], "👑")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- keep server-verified collaboration roles fully authoritative for role badges, icons, colors, and filters;
- for `generic_actor` messages, show the authenticated OAuth `client_name` with an explicit `· OAUTH` marker instead of rendering every participant as the indistinguishable `AGENT` label;
- keep generic authors in the neutral `agent` role ID, so the presentation fallback cannot grant or imply manager/dev/researcher/AI-engineer authority;
- add focused regression tests for camelCase and snake_case payloads, sanitization, message-text spoof resistance, and verified-role precedence.

## Why

With clients that create a fresh MCP transport for every tool call, the private collaboration context is not available to `agent_chat_post`. Those messages are correctly persisted as `generic_actor`, but the TUI rendered all of them with the same `AGENT` tag even when separate OAuth clients had distinct role-oriented client names.

This patch improves the operator-facing label without weakening the collaboration trust boundary. A truly verified role badge still requires either reuse of the server-issued `Mcp-Session-Id` or a trusted, stable, non-model-visible logical-session binding.

## Limitation

When several logical agents share the same OAuth client name, PiLink still cannot determine their distinct roles from an unbound fresh transport. Solving that requires transport continuity; inferring from message text or public session IDs would be spoofable.